### PR TITLE
add specificity to hubID selector -- fix issue with new trials nav item

### DIFF
--- a/design-manager.js
+++ b/design-manager.js
@@ -316,7 +316,7 @@ $(document).ready(function() {
                 /*get current HubSpot ID*/
                 var hubId;
                 waitForEl(".navtools", function () {
-                    hubId = $(".navtools .settings > a").attr("href").split("/user-preferences/")[1].split("?")[0];
+                    hubId = $(".navtools .settings > #navSetting").attr("href").split("/user-preferences/")[1].split("?")[0];
                     /*inject dev menu*/
                     generateDevMenu(hubId);
                 });


### PR DESCRIPTION
Your checklist for this pull request
🚨Please review the guidelines for contributing to this repository.

[x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Do not pull request to Master please.(when in doubt request Develop branch)
[x] Test to make sure your feature/bugfix doesn't break other features ;)
[x] Write a meaningful description of what your changes are.
[x] Wait patiently and celebrate, you've submitted changes to the extension!

Hubspot recently added a trials nav item next to the settings cog on certain portals ( pretty much all of the ones that I am in on a daily basis) and this is causing the extension to no longer create the the developer nav item.

![Screen Shot 2022-05-17 at 10 44 40 AM](https://user-images.githubusercontent.com/39243773/168853145-05aa6c96-bc28-4352-865a-1ec2beee3a1b.jpg)

A simple selector specificity change seems to do the trick. 
